### PR TITLE
error correction in MSC

### DIFF
--- a/chemsy/prep/methods.py
+++ b/chemsy/prep/methods.py
@@ -224,7 +224,7 @@ class MSC(BaseEstimator,TransformerMixin):
         #self.mean= np.array(X.mean(axis=0))
         def transformMSC(x,mean):
             m,b= np.polyfit(mean,x,1)
-            return (x-b)*m
+            return (x-b)/m
         return X.apply(transformMSC,args=(self.mean,),axis=1).values
 
     def fit_transform(self,X,y=None):
@@ -235,7 +235,7 @@ class MSC(BaseEstimator,TransformerMixin):
         self.mean= np.array(X.mean(axis=0))
         def transformMSC(x,mean):
             m,b= np.polyfit(mean,x,1)
-            return (x-b)*m
+            return (x-b)/m
         return X.apply(transformMSC,args=(self.mean,),axis=1).values
 
 


### PR DESCRIPTION
I found a bug in the MSC code. The x matrix was corrected by subtracting the offset and multiplying by the slope. It should however be divided by the slope. https://docs.labcognition.com/panorama/en/multiplicative_scatter_correction/